### PR TITLE
Customize Jekyll example for sherlockramos blog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,3 +30,5 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
 # Webrick not installed by default in Ruby 3.0+
 gem "webrick"
+gem "csv"
+gem "base64"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,11 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
     bigdecimal (3.1.8)
     colorator (1.1.0)
     concurrent-ruby (1.3.3)
+    csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -79,6 +81,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  base64
+  csv
   jekyll (~> 4.3.0)
   jekyll-feed (~> 0.12)
   minima (~> 2.5)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Jekyll Example
+# sherlockramos
 
-This directory is a brief example of a [Jekyll](https://jekyllrb.com/) site that can be deployed to Vercel with zero configuration.
+Este repositório contém o código do blog **sherlockramos**, baseado em [Jekyll](https://jekyllrb.com/).
+Ele pode ser implantado na Vercel com configuração mínima.
 
 ## Deploy Your Own
 

--- a/_config.yml
+++ b/_config.yml
@@ -18,21 +18,25 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
-title: Your awesome title
-email: your-email@example.com
-description: >- # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+title: sherlockramos
+email: ""
+description: >-
+  Blog pessoal sobre tecnologia e investigacao mantido por Sherlock Ramos.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
 
+header_pages:
+  - index.md
+  - blog.md
+  - contact.md
+
 # Build settings
 theme: minima
 plugins:
   - jekyll-feed
+show_excerpts: true
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+<div class="home">
+  {{ content }}
+  {% if site.posts.size > 0 %}
+    <h2 class="post-list-heading">Posts Recentes</h2>
+    <ul class="post-list">
+    {% assign recent_posts = site.posts | slice: 0, 3 %}
+    {% for post in recent_posts %}
+      <li>
+        {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
+        <span class="post-meta">{{ post.date | date: date_format }}</span>
+        <h3>
+          <a class="post-link" href="{{ post.url | relative_url }}">
+            {{ post.title | escape }}
+          </a>
+        </h3>
+        {% if site.show_excerpts %}
+          {{ post.excerpt }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+    <p class="rss-subscribe">Acompanhe todos os posts na <a href="{{ '/blog/' | relative_url }}">página do blog</a>.</p>
+  {% endif %}
+</div>

--- a/_posts/2023-12-01-second-post.md
+++ b/_posts/2023-12-01-second-post.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Investigando Novos Mistérios"
+date: 2023-12-01 12:00:00 +0000
+categories: atualizacoes
+---
+
+Bem-vindo ao segundo post do blog **sherlockramos**. Aqui começamos a explorar assuntos de tecnologia e investigação.

--- a/_posts/2024-05-10-third-post.md
+++ b/_posts/2024-05-10-third-post.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Sherlock e o Mundo Tech"
+date: 2024-05-10 08:00:00 +0000
+categories: novidades
+---
+
+Este é o terceiro post do site **sherlockramos**. Acompanhe aqui dicas e reflexões sobre tecnologia e curiosidades investigativas.

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,4 @@
+---
+---
+$brand-color: #001f3f;
+@import "minima";

--- a/blog.md
+++ b/blog.md
@@ -1,0 +1,7 @@
+---
+layout: home
+title: Blog
+permalink: /blog/
+---
+
+Acompanhe todos os artigos publicados no **sherlockramos**.

--- a/contact.md
+++ b/contact.md
@@ -1,0 +1,11 @@
+---
+layout: page
+title: Contato
+permalink: /contato/
+---
+
+Siga **sherlockramos** nas redes sociais:
+
+- [GitHub](https://github.com/sherlockramos)
+- [Twitter](https://twitter.com/sherlockramos)
+- [LinkedIn](https://www.linkedin.com/in/sherlockramos)

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
-# Feel free to add content and custom Front Matter to this file.
-# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
-
-layout: home
+layout: index
+title: Home
 ---
+
+Bem-vindo ao **sherlockramos**! Aqui você encontra conteúdos sobre tecnologia e investigação.


### PR DESCRIPTION
## Summary
- rename site to **sherlockramos** and configure navigation
- add pages for blog index and social contacts
- show last three posts on the homepage
- style site with a navy brand color
- add two sample posts

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6849d4aea4e8832c9d40031e8b904dcb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a custom homepage layout displaying recent posts and excerpts.
	- Added dedicated pages for Blog and Contact, including social media links.
	- Published two new blog posts: "Investigando Novos Mistérios" and "Sherlock e o Mundo Tech".

- **Enhancements**
	- Updated site metadata and configuration, including title, description, and navigation links.
	- Added support for post excerpts on the homepage.
	- Customized site styling with a new brand color.

- **Documentation**
	- Updated the README and site content to Portuguese, reflecting the new blog identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->